### PR TITLE
fixing java 8 compat mode for gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.springframework.boot' version '1.5.6.RELEASE'
-    id 'java'
+    id 'java' sourceCompatibility '1.8' targetCompatibility 1.8
 }
 
 group 'alto'
@@ -9,8 +9,6 @@ version '1.0-SNAPSHOT'
 springBoot {
     mainClass = "AltoApplication"
 }
-
-sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
pretty simple - but this will allow new people using intellij to not have to hack any settings since gradle will automatically set the correct language level. 